### PR TITLE
feat: overhaul cli command structure

### DIFF
--- a/cspell.config.yml
+++ b/cspell.config.yml
@@ -27,9 +27,12 @@ words:
   - lcov
   - libsql
   - lucaschultz
+  - mydb
+  - myorg
   - notnull
   - packagejson
   - preinstall
   - stricli
   - tseslint
   - tsup
+  - turso

--- a/package.json
+++ b/package.json
@@ -25,8 +25,9 @@
   ],
   "scripts": {
     "build": "tsup",
+    "ci": "pnpm run tsc && pnpm run test && pnpm run lint:fix && pnpm run lint:knip && pnpm run lint:md && pnpm run lint:spelling && pnpm run format:check",
     "format": "prettier --list-different --write .",
-    "format:check": "prettier --list-different --check .",
+    "format:check": "prettier --check .",
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix --max-warnings 0",
     "lint:knip": "knip",

--- a/src/cli/app.ts
+++ b/src/cli/app.ts
@@ -1,14 +1,29 @@
-import { buildApplication } from '@stricli/core'
+import { buildApplication, buildRouteMap } from '@stricli/core'
 
-import { name, version } from '../../package.json'
+import { version } from '../../package.json'
 import { LibSqlCommand } from './commands/libsql-command.js'
 
-export const app = buildApplication(LibSqlCommand, {
-  name,
+const routeMap = buildRouteMap({
+  docs: {
+    brief: 'Generate ERD diagrams from various sources',
+  },
+  routes: {
+    libsql: LibSqlCommand,
+    sqlite: LibSqlCommand,
+  },
+})
+
+export const app = buildApplication(routeMap, {
+  documentation: {
+    caseStyle: 'convert-camel-to-kebab',
+    useAliasInUsageLine: true,
+  },
+  name: 'erd-generator',
   scanner: {
     caseStyle: 'allow-kebab-for-camel',
   },
   versionInfo: {
     currentVersion: version,
+    upgradeCommand: 'npm install -g erd-generator',
   },
 })

--- a/src/cli/parsers/parse-output-arg.ts
+++ b/src/cli/parsers/parse-output-arg.ts
@@ -3,7 +3,7 @@ import path from 'path'
 
 export async function checkIfFileExists(filePath: string): Promise<boolean> {
   try {
-    await fs.access(filePath)
+    await fs.access(filePath, fs.constants.R_OK)
     return true
   } catch {
     return false


### PR DESCRIPTION
This PR introduces a command structure which will support the addition of other database types (by adding `Introspectors`) and other diagram markup languages (by adding `Renderers`). In the new structure, the subcommand choses the which database type will be used (currently `sqlite` or `libSQL`) and the `--format` flag will determine the output format (currently only `d2` which is also the default). A complete list of changes:

- Add `libsql`/`sqlite` subcommands
- `—format` flag for diagram format (currently only `d2` suppported)
- `—exclude-table` flag to exlude tables from diagrams
- `—generated-tables` flag to include generated tables
- Improve parsing/validation of libsql/sqlite url argument
- Improve flag summaries
- Improve flag placeholders